### PR TITLE
declared inline function as extern

### DIFF
--- a/tamper.h
+++ b/tamper.h
@@ -7,7 +7,7 @@
 #include "string_ops.h"
 #include "validate.h"
 
-inline char* encode64(char* str, unsigned long len);
+extern inline char* encode64(char* str, unsigned long len);
 char *rand_case(char *str); 
 char *urlencode(char *str); 
 char *double_urlencode( char *str);


### PR DESCRIPTION
When I tried to compile the actual version I got the following error:
> gcc -W -Wall -Wextra -O2 -fstack-protector-all -D_FORTIFY_SOURCE=2 -c *.c
In file included from spider.h:21:0,
                 from 0d1n.c:45:
tamper.h:10:14: warning: inline function 'encode64' declared but never defined
 inline char* encode64(char* str, unsigned long len);
              ^
In file included from spider.h:21:0,
                 from spider.c:1:
tamper.h:10:14: warning: inline function 'encode64' declared but never defined
 inline char* encode64(char* str, unsigned long len);
              ^
gcc -o 0d1n *.o -Wl,-z,relro,-z,now -lcurl
spider.o: In function `spider':
spider.c:(.text+0x104): undefined reference to `encode64'
collect2: error: ld returned 1 exit status
Makefile:10: recipe for target '0d1n' failed
make: *** [0d1n] Error 1

To fix this I defined the inline function of encode64 as external. I have very small knowledge of C so I hope my fix is correct.