### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-##0d1n
+## 0d1n
 =====
 ![Alt text](https://github.com/CoolerVoid/0d1n/blob/master/doc/images/overview1.png)
 0d1n is a tool for automating customized attacks against web applications.
 
 
-#You can do: 
+# You can do: 
 
 > *brute force login and passwords in auth forms
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
