### PR TITLE
Pass -dead_strip,-bind_at_load on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ CC=gcc
 CFLAGS=-W -Wall -Wextra -fstack-protector-all
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
-	LDFLAGS=-Wl,-lcurl
+	LDFLAGS=-Wl,-dead_strip,-bind_at_load, -lcurl
 else
 	LDFLAGS=-Wl,-z,relro,-z,now -lcurl
 endif


### PR DESCRIPTION
From `man ld`:
```
-dead_strip
                 Remove functions and data that are unreachable by the entry point or exported symbols.
```

From `man ld`:
```
-bind_at_load
                 Sets a bit in the mach header of the resulting binary which tells dyld to bind all symbols when the binary is loaded,
                 rather than lazily.
```
Essentially, `-bind_at_load` is the equivalent of `-Wl,-z,now` on Linux.

Before:
```
% wc -c 0d1n
   63980 0d1n
% otool -l 0d1n
            cmd LC_DYLD_INFO_ONLY
        cmdsize 48
     rebase_off 57344
    rebase_size 16
       bind_off 57360
      bind_size 104
  weak_bind_off 0
 weak_bind_size 0
  lazy_bind_off 57464
 lazy_bind_size 1248
     export_off 58712
    export_size 960
```
After:
```
% wc -c 0d1n
   63572 0d1n
% otool -l 0d1n
            cmd LC_DYLD_INFO_ONLY
        cmdsize 48
     rebase_off 57344
    rebase_size 16
       bind_off 57360
      bind_size 1032
  weak_bind_off 0
 weak_bind_size 0
  lazy_bind_off 0
 lazy_bind_size 0
     export_off 58392
    export_size 936
```